### PR TITLE
Add skeleton streaming XML to JSON converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
 # LargeXmlToJsonConverter
+
+A streaming XML to JSON conversion library with a CLI tool. Designed to handle very large XML files (up to multiple gigabytes) using `XmlReader` and `Utf8JsonWriter` without loading entire documents into memory.
+
+## Projects
+
+- **LargeXmlToJsonConverter** – core class library.
+- **LargeXmlToJsonTool** – command line interface.
+- **LargeXmlToJsonConverter.Tests** – xUnit tests.
+
+## Building
+
+Use the .NET 6 SDK:
+
+```bash
+# restore and build
+ dotnet build
+```
+
+## CLI Usage
+
+```bash
+largexmltojsontool --input input.xml --output output.json --indent
+```
+
+## Testing
+
+Run unit tests with:
+
+```bash
+ dotnet test
+```
+

--- a/src/LargeXmlToJsonConverter/ConversionOptions.cs
+++ b/src/LargeXmlToJsonConverter/ConversionOptions.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace LargeXmlToJsonConverter
+{
+    /// <summary>
+    /// Options controlling XML to JSON conversion.
+    /// </summary>
+    public class ConversionOptions
+    {
+        /// <summary>
+        /// Gets a default set of options.
+        /// </summary>
+        public static ConversionOptions Default { get; } = new ConversionOptions();
+
+        /// <summary>
+        /// Options for the underlying JSON writer.
+        /// </summary>
+        public JsonWriterOptions JsonWriterOptions { get; set; } = new JsonWriterOptions { Indented = false };
+    }
+}

--- a/src/LargeXmlToJsonConverter/LargeXmlToJsonConverter.csproj
+++ b/src/LargeXmlToJsonConverter/LargeXmlToJsonConverter.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+</Project>

--- a/src/LargeXmlToJsonConverter/XmlConversionException.cs
+++ b/src/LargeXmlToJsonConverter/XmlConversionException.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace LargeXmlToJsonConverter
+{
+    /// <summary>
+    /// Represents errors that occur during XML to JSON conversion.
+    /// </summary>
+    public class XmlConversionException : Exception
+    {
+        public XmlConversionException(string message, Exception? inner = null)
+            : base(message, inner)
+        {
+        }
+    }
+}

--- a/src/LargeXmlToJsonConverter/XmlToJsonConverter.cs
+++ b/src/LargeXmlToJsonConverter/XmlToJsonConverter.cs
@@ -1,0 +1,124 @@
+using System;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+namespace LargeXmlToJsonConverter
+{
+    /// <summary>
+    /// Streaming XML to JSON converter.
+    /// </summary>
+    public class XmlToJsonConverter
+    {
+        private readonly ILogger<XmlToJsonConverter> _logger;
+
+        public XmlToJsonConverter(ILogger<XmlToJsonConverter>? logger = null)
+        {
+            _logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<XmlToJsonConverter>.Instance;
+        }
+
+        /// <summary>
+        /// Convert XML from input stream to JSON on output stream using provided options.
+        /// </summary>
+        public void Convert(Stream input, Stream output, ConversionOptions? options = null)
+        {
+            options ??= ConversionOptions.Default;
+            using var reader = XmlReader.Create(input, new XmlReaderSettings { Async = false });
+            using var writer = new Utf8JsonWriter(output, options.JsonWriterOptions);
+            ConvertInternal(reader, writer, options, CancellationToken.None);
+            writer.Flush();
+        }
+
+        /// <summary>
+        /// Asynchronously convert XML to JSON.
+        /// </summary>
+        public async Task ConvertAsync(Stream input, Stream output, ConversionOptions? options = null, CancellationToken cancellationToken = default)
+        {
+            options ??= ConversionOptions.Default;
+            using var reader = XmlReader.Create(input, new XmlReaderSettings { Async = true });
+            using var writer = new Utf8JsonWriter(output, options.JsonWriterOptions);
+            await ConvertInternalAsync(reader, writer, options, cancellationToken).ConfigureAwait(false);
+            await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+
+        private void ConvertInternal(XmlReader reader, Utf8JsonWriter writer, ConversionOptions options, CancellationToken ct)
+        {
+            try
+            {
+                WriteJson(reader, writer, options, ct).GetAwaiter().GetResult();
+            }
+            catch (OutOfMemoryException oom)
+            {
+                throw new XmlConversionException("Ran out of memory during conversion", oom);
+            }
+            catch (XmlException xe)
+            {
+                throw new XmlConversionException($"Malformed XML at line {xe.LineNumber}, position {xe.LinePosition}", xe);
+            }
+        }
+
+        private async Task ConvertInternalAsync(XmlReader reader, Utf8JsonWriter writer, ConversionOptions options, CancellationToken ct)
+        {
+            try
+            {
+                await WriteJson(reader, writer, options, ct).ConfigureAwait(false);
+            }
+            catch (OutOfMemoryException oom)
+            {
+                throw new XmlConversionException("Ran out of memory during conversion", oom);
+            }
+            catch (XmlException xe)
+            {
+                throw new XmlConversionException($"Malformed XML at line {xe.LineNumber}, position {xe.LinePosition}", xe);
+            }
+        }
+
+        private async Task WriteJson(XmlReader reader, Utf8JsonWriter writer, ConversionOptions options, CancellationToken ct)
+        {
+            var depth = 0;
+            while (await reader.ReadAsync().ConfigureAwait(false))
+            {
+                ct.ThrowIfCancellationRequested();
+                switch (reader.NodeType)
+                {
+                    case XmlNodeType.Element:
+                        writer.WriteStartObject();
+                        writer.WriteString("name", reader.Name);
+                        if (reader.HasAttributes)
+                        {
+                            writer.WriteStartObject("attributes");
+                            while (reader.MoveToNextAttribute())
+                            {
+                                writer.WriteString(reader.Name, reader.Value);
+                            }
+                            writer.WriteEndObject();
+                            reader.MoveToElement();
+                        }
+                        if (reader.IsEmptyElement)
+                        {
+                            writer.WriteEndObject();
+                        }
+                        depth++;
+                        break;
+                    case XmlNodeType.Text:
+                        writer.WriteString("text", reader.Value);
+                        break;
+                    case XmlNodeType.EndElement:
+                        writer.WriteEndObject();
+                        depth--;
+                        break;
+                }
+            }
+            while (depth > 0)
+            {
+                writer.WriteEndObject();
+                depth--;
+            }
+        }
+    }
+}
+

--- a/src/LargeXmlToJsonTool/LargeXmlToJsonTool.csproj
+++ b/src/LargeXmlToJsonTool/LargeXmlToJsonTool.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <ProjectReference Include="../LargeXmlToJsonConverter/LargeXmlToJsonConverter.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/LargeXmlToJsonTool/Program.cs
+++ b/src/LargeXmlToJsonTool/Program.cs
@@ -1,0 +1,30 @@
+using System.CommandLine;
+using System.CommandLine.Binding;
+using LargeXmlToJsonConverter;
+using Microsoft.Extensions.Logging;
+
+var inputOption = new Option<string>("--input", description: "Path to input XML file") { IsRequired = true };
+var outputOption = new Option<string>("--output", description: "Path for output JSON file") { IsRequired = true };
+var indentOption = new Option<bool>("--indent", () => false, "Indent JSON output");
+var rootCommand = new RootCommand("Large XML to JSON Converter")
+{
+    inputOption,
+    outputOption,
+    indentOption
+};
+
+rootCommand.SetHandler(async (string input, string output, bool indent) =>
+{
+    using var inputStream = File.OpenRead(input);
+    using var outputStream = File.Create(output);
+    var loggerFactory = LoggerFactory.Create(builder => builder.AddSimpleConsole());
+    var logger = loggerFactory.CreateLogger<XmlToJsonConverter>();
+    var converter = new XmlToJsonConverter(logger);
+    var options = new ConversionOptions
+    {
+        JsonWriterOptions = new System.Text.Json.JsonWriterOptions { Indented = indent }
+    };
+    await converter.ConvertAsync(inputStream, outputStream, options);
+}, inputOption, outputOption, indentOption);
+
+return await rootCommand.InvokeAsync(args);

--- a/tests/LargeXmlToJsonConverter.Tests/LargeXmlToJsonConverter.Tests.csproj
+++ b/tests/LargeXmlToJsonConverter.Tests/LargeXmlToJsonConverter.Tests.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <ProjectReference Include="../../src/LargeXmlToJsonConverter/LargeXmlToJsonConverter.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/LargeXmlToJsonConverter.Tests/SimpleConversionTests.cs
+++ b/tests/LargeXmlToJsonConverter.Tests/SimpleConversionTests.cs
@@ -1,0 +1,23 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LargeXmlToJsonConverter.Tests
+{
+    public class SimpleConversionTests
+    {
+        [Fact]
+        public async Task ConvertsSimpleXml()
+        {
+            var xml = "<root><child attr='1'>text</child></root>";
+            await using var input = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            await using var output = new MemoryStream();
+            var converter = new LargeXmlToJsonConverter.XmlToJsonConverter();
+            await converter.ConvertAsync(input, output);
+            var json = Encoding.UTF8.GetString(output.ToArray());
+            Assert.Contains("\"child\"", json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a class library and CLI project
- implement a basic streaming XmlToJsonConverter
- provide CLI entrypoint
- add xUnit test project
- update README with instructions

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843e6dbb07c832b90b3c7d2ed5a952f