### PR TITLE
Add custom node converter option

### DIFF
--- a/src/LargeXmlToJsonConverter/ConversionOptions.cs
+++ b/src/LargeXmlToJsonConverter/ConversionOptions.cs
@@ -16,5 +16,11 @@ namespace LargeXmlToJsonConverter
         /// Options for the underlying JSON writer.
         /// </summary>
         public JsonWriterOptions JsonWriterOptions { get; set; } = new JsonWriterOptions { Indented = false };
+
+        /// <summary>
+        /// Optional custom node converter invoked for each XML node. Should return
+        /// <c>true</c> if the node was handled and no further processing is required.
+        /// </summary>
+        public Func<XmlReader, Utf8JsonWriter, CancellationToken, Task<bool>>? NodeConverter { get; set; }
     }
 }

--- a/src/LargeXmlToJsonConverter/XmlToJsonConverter.cs
+++ b/src/LargeXmlToJsonConverter/XmlToJsonConverter.cs
@@ -83,6 +83,12 @@ namespace LargeXmlToJsonConverter
             while (await reader.ReadAsync().ConfigureAwait(false))
             {
                 ct.ThrowIfCancellationRequested();
+
+                if (options.NodeConverter != null && await options.NodeConverter(reader, writer, ct).ConfigureAwait(false))
+                {
+                    continue;
+                }
+
                 switch (reader.NodeType)
                 {
                     case XmlNodeType.Element:

--- a/tests/LargeXmlToJsonConverter.Tests/CustomConverterTests.cs
+++ b/tests/LargeXmlToJsonConverter.Tests/CustomConverterTests.cs
@@ -1,0 +1,37 @@
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace LargeXmlToJsonConverter.Tests
+{
+    public class CustomConverterTests
+    {
+        [Fact]
+        public async Task UsesCustomConverter()
+        {
+            var xml = "<root><child attr='1'>text</child></root>";
+            await using var input = new MemoryStream(Encoding.UTF8.GetBytes(xml));
+            await using var output = new MemoryStream();
+            var converter = new LargeXmlToJsonConverter.XmlToJsonConverter();
+            var options = new LargeXmlToJsonConverter.ConversionOptions
+            {
+                NodeConverter = (reader, writer, ct) =>
+                {
+                    if (reader.NodeType == System.Xml.XmlNodeType.Element && reader.Name == "child")
+                    {
+                        writer.WriteString("custom", reader.GetAttribute("attr") ?? string.Empty);
+                        reader.Skip();
+                        return Task.FromResult(true);
+                    }
+                    return Task.FromResult(false);
+                }
+            };
+            await converter.ConvertAsync(input, output, options, CancellationToken.None);
+            var json = Encoding.UTF8.GetString(output.ToArray());
+            Assert.Contains("custom", json);
+            Assert.DoesNotContain("\"child\"", json);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- allow passing a custom node converter via `ConversionOptions`
- invoke the custom converter inside `XmlToJsonConverter.WriteJson`
- add unit test verifying custom converter usage

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843ebed017c832baf9abbced93bd70c